### PR TITLE
changes helpers to use Ember.Helper.helper bc deprecations

### DIFF
--- a/addon/helpers/class-state.js
+++ b/addon/helpers/class-state.js
@@ -8,4 +8,4 @@ export function classState([value, trueClass, falseClass, initialClass]) {
   return value ? trueClass : falseClass;
 }
 
-export default Ember.HTMLBars.makeBoundHelper(classState);
+export default Ember.Helper.helper(classState);

--- a/addon/helpers/first.js
+++ b/addon/helpers/first.js
@@ -4,4 +4,4 @@ export function first([errors]) {
   return errors[0];
 }
 
-export default Ember.HTMLBars.makeBoundHelper(first);
+export default Ember.Helper.helper(first);

--- a/tests/dummy/app/helpers/is-equal.js
+++ b/tests/dummy/app/helpers/is-equal.js
@@ -4,4 +4,4 @@ export function isEqual(a, b){
   return a === b;
 }
 
-export default Ember.HTMLBars.makeBoundHelper(isEqual);
+export default Ember.Helper.helper(isEqual);


### PR DESCRIPTION
3 deprecated usages of `Ember.HTMLBars.makeBoundHelper` changed to `Ember.Helper.helper`
