### PR TITLE
Dependency: Remove unnecessary `ember-getowner-polyfill`

### DIFF
--- a/addon/components/validation-wrapper/component.js
+++ b/addon/components/validation-wrapper/component.js
@@ -1,12 +1,12 @@
 import Ember from 'ember';
 import layout from './template';
 import runValidations from '../../utils/run-validations';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   Component,
   computed,
-  run
+  run,
+  getOwner
   } = Ember;
 
 export default Component.extend({

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "ember-data": "^2.5.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-getowner-polyfill": "1.0.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-suave": "2.0.1",


### PR DESCRIPTION
`getOwner` is native to Ember 2.3+
