### PR TITLE
Bug Fix: Use RSVP.Promise instead of Promise

### DIFF
--- a/addon/components/validated-form/component.js
+++ b/addon/components/validated-form/component.js
@@ -4,7 +4,8 @@ import layout from './template';
 const {
   A,
   computed,
-  Component
+  Component,
+  RSVP
   } = Ember;
 
 export default Component.extend({
@@ -75,7 +76,7 @@ export default Component.extend({
       };
 
       if (this.get('isValid')) {
-        new Promise((resolve, reject) => {
+        new RSVP.Promise((resolve, reject) => {
           this.set('_promiseState', 'pending');
           this.sendAction('action', reset, resolve, reject);
         })


### PR DESCRIPTION
`Promise` was not found when I ran `ember test` in an Ember 2.4 app. 

Using `node` 5.10.1, `phantomjs-prebuilt` 2.1.7
