### PR TITLE
Allow dynamic re-rendering

### DIFF
--- a/addon/components/validated-form/component.js
+++ b/addon/components/validated-form/component.js
@@ -64,6 +64,10 @@ export default Component.extend({
       this.get('fields').pushObject(params);
     },
 
+    unregister(params) {
+      this.get('fields').removeObject(params);
+    },
+
     submit() {
 
       this.get('fields').forEach((field) => {

--- a/addon/components/validated-form/template.hbs
+++ b/addon/components/validated-form/template.hbs
@@ -10,6 +10,6 @@
 	  reset=(action 'reset')
 	  errors=submitErrors
 	  state=formState
-    validation=(component 'validation-wrapper' register=(action 'register'))
+    validation=(component 'validation-wrapper' register=(action 'register') unregister=(action 'unregister'))
   )
 }}

--- a/addon/components/validation-wrapper/component.js
+++ b/addon/components/validation-wrapper/component.js
@@ -116,5 +116,10 @@ export default Component.extend({
     this.set('selectedRules', rules);
 
     register(this);
+  },
+
+  willDestroyElement() {
+    let unregister = this.get('unregister');
+    unregister(this);
   }
 });


### PR DESCRIPTION
We have run into a form which the visibility of some fields are depending on the value of another field, something like:

```
<select1 value=model.value1></select>
{{#if eq model.value1 'a'}}
   <input value=model.value2>
{{else}}
   <input value=model.value3> 
{{/if}}
```

So each time when selection of select1 changes one field will get destroyed and another will get created.   So I think adding unregister and call it from fields.willDestroyElement might keep the fields in validated-form clean. 
