### PR TITLE
validation fix in firefox and IOS

### DIFF
--- a/app/validations/date.js
+++ b/app/validations/date.js
@@ -4,7 +4,7 @@ import moment from 'moment';
 export default Validation.create({
   validate(value, errors) {
     const result = /Invalid|NaN/.test(new Date(value).toString());
-    const valid = moment(value, 'MM-DD-YYYY').isValid();
+    const valid = moment(value, 'YYYY-MM-DD').isValid();
 
     if (result || !valid) {
       const message = this.getWithDefault('dateMessage', 'Please enter a valid date.');

--- a/tests/unit/validations/date-test.js
+++ b/tests/unit/validations/date-test.js
@@ -5,7 +5,7 @@ import { module, test } from 'qunit';
 module('Unit | Validation | date');
 
 test('valid', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   const Context = Ember.Object.extend({});
   const date = dateValidator.validate.bind(Context.create({}));
@@ -13,6 +13,7 @@ test('valid', function(assert) {
 
   assert.deepEqual(date('06/06/1990', []), errors);
   assert.deepEqual(date('6/6/06', []), errors);
+  assert.deepEqual(date('1990-06-06', []), errors);
 });
 
 test('inValid', function(assert) {


### PR DESCRIPTION
If you check `new Date(MM-DD-YYYY)` will not working in Firefox and IE9, IOS devices. But this will only work in chrome. 

Changed MM-DD-YYY to YYYY-MM-DD as per the [ECMA](http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15)
