### PR TITLE
Fix for PhantomJS which fails in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1.13
+  - EMBER_TRY_SCENARIO=ember-2.3.0
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,8 @@
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "bootstrap": "~3.3.5"
+    "bootstrap": "~3.3.5",
+    "es5-shim": "^4.5.8"
   },
   "devDependencies": {
     "blanket": "5e94fc30f2e694bb5c3718ddcbf60d467f4b4d26"

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,13 +8,13 @@ module.exports = {
       }
     },
     {
-      name: 'ember-1.13',
+      name: 'ember-2.3.0',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
+          'ember': '~2.3.0'
         },
         resolutions: {
-          'ember': '~1.13.0'
+          'ember': '~2.3.0'
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall",
-    "postinstall": "ember g ember-cli-es5-shim"
+    "test": "ember try:testall"
   },
   "repository": "https://github.com/sethpollack/ember-stickler",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall"
+    "test": "ember try:testall",
+    "postinstall": "ember g ember-cli-es5-shim"
   },
   "repository": "https://github.com/sethpollack/ember-stickler",
   "engines": {
@@ -35,6 +36,7 @@
     "ember-cli-blanket": "0.9.4",
     "ember-cli-changelog": "0.3.4",
     "ember-cli-dependency-checker": "^1.2.0",
+    "ember-cli-es5-shim": "^0.3.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",


### PR DESCRIPTION
Fix for below

```
TypeError: 'undefined' is not a function (evaluating '_dummyValidationsCreditCard['default'].validate.bind(Context.create({}))')
```

on running in PhantomJS 1.9 
